### PR TITLE
Add Facebook pipeline configuration

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -117,6 +117,11 @@ if __name__ == "__main__":
         for row in engagement_counts.values():
             writer.writerow(row)
 
+    if pipeline_configuration.pipeline_name == "TIS-Plus-Facebook":
+        # Only the total engagement counts make sense for now, so don't attempt to apply any of the other standard
+        # analysis to the Facebook data.
+        exit(0)
+
     log.info("Computing the participation frequencies...")
     repeat_participations = OrderedDict()
     for i in range(1, len(PipelineConfiguration.RQA_CODING_PLANS) + 1):

--- a/code_schemes/facebook_comment_reply_to.json
+++ b/code_schemes/facebook_comment_reply_to.json
@@ -1,0 +1,47 @@
+{
+  "SchemeID": "Scheme-aab247b7",
+  "Name": "Comment Reply To",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-450ec146",
+      "CodeType": "Normal",
+      "DisplayText": "post",
+      "NumericValue": 1,
+      "StringValue": "post",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "post"
+      ]
+    },
+    {
+      "CodeID": "code-59abc42a",
+      "CodeType": "Normal",
+      "DisplayText": "comment",
+      "NumericValue": 2,
+      "StringValue": "comment",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "comment"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/facebook_post_type.json
+++ b/code_schemes/facebook_post_type.json
@@ -1,0 +1,47 @@
+{
+  "SchemeID": "Scheme-3cd48f7c",
+  "Name": "Post Type",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-d5b87090",
+      "CodeType": "Normal",
+      "DisplayText": "photo",
+      "NumericValue": 1,
+      "StringValue": "photo",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "photo"
+      ]
+    },
+    {
+      "CodeID": "code-2c6a6da3",
+      "CodeType": "Normal",
+      "DisplayText": "video",
+      "NumericValue": 2,
+      "StringValue": "video",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "video"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": false
+    }
+  ]
+}

--- a/code_schemes/facebook_s01e01.json
+++ b/code_schemes/facebook_s01e01.json
@@ -1,0 +1,179 @@
+{
+    "SchemeID": "Scheme-a987cc0b",
+    "Name": "Facebook S01E01",
+    "Version": "0.0.0.1",
+    "Codes": [
+
+      {
+        "CodeID": "code-NA-f93d3eb7",
+        "CodeType": "Control",
+        "ControlCode": "NA",
+        "DisplayText": "NA (missing)",
+        "NumericValue": -10,
+        "StringValue": "NA",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NS-2c11b7c9",
+        "CodeType": "Control",
+        "ControlCode": "NS",
+        "DisplayText": "NS (skip)",
+        "NumericValue": -20,
+        "StringValue": "NS",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NC-42f1d983",
+        "CodeType": "Control",
+        "ControlCode": "NC",
+        "DisplayText": "NC (not coded)",
+        "NumericValue": -30,
+        "StringValue": "NC",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-NR-5e3eee23",
+        "CodeType": "Control",
+        "ControlCode": "NR",
+        "DisplayText": "NR (not reviewed)",
+        "NumericValue": -40,
+        "StringValue": "NR",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-NIC-99631cb8",
+        "CodeType": "Control",
+        "ControlCode": "NIC",
+        "DisplayText": "NIC (not internally consistent)",
+        "NumericValue": -50,
+        "StringValue": "NIC",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-STOP-08b832a8",
+        "CodeType": "Control",
+        "ControlCode": "STOP",
+        "DisplayText": "STOP",
+        "NumericValue": -90,
+        "StringValue": "STOP",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-WS-adb25603b7af",
+        "CodeType": "Control",
+        "ControlCode": "WS",
+        "DisplayText": "WS (wrong scheme)",
+        "NumericValue": -100,
+        "StringValue": "WS",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-CE-016c1e22",
+        "CodeType": "Control",
+        "ControlCode": "CE",
+        "DisplayText": "CE (coding error)",
+        "NumericValue": -110,
+        "StringValue": "CE",
+        "VisibleInCoda": false
+      },
+      {
+        "CodeID": "code-PB-a434a800",
+        "CodeType": "Meta",
+        "MetaCode": "push_back",
+        "DisplayText": "meta: push back",
+        "NumericValue": -100000,
+        "StringValue": "push_back",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SQ-5e8f0122",
+        "CodeType": "Meta",
+        "MetaCode": "showtime_question",
+        "DisplayText": "meta: showtime question",
+        "NumericValue": -100030,
+        "StringValue": "showtime_question",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-G-97cb3199",
+        "CodeType": "Meta",
+        "MetaCode": "greeting",
+        "DisplayText": "meta: greeting",
+        "NumericValue": -100020,
+        "StringValue": "greeting",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-OI-c5f1d054",
+        "CodeType": "Meta",
+        "MetaCode": "opt-in",
+        "DisplayText": "meta: opt-in",
+        "NumericValue": -100040,
+        "StringValue": "opt_in",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-SC-a3a065bc",
+        "CodeType": "Meta",
+        "MetaCode": "similar_content",
+        "DisplayText": "meta: similar content",
+        "NumericValue": -100050,
+        "StringValue": "similar_content",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-PI-83b90d32",
+        "CodeType": "Meta",
+        "MetaCode": "participation_incentive",
+        "DisplayText": "meta: participation incentive",
+        "NumericValue": -100060,
+        "StringValue": "participation_incentive",
+        "VisibleInCoda": true
+      },
+      {
+        "CodeID": "code-EC-3a704f5b",
+        "CodeType": "Meta",
+        "MetaCode": "exclusion_complaint",
+        "DisplayText": "meta: exclusion complaint",
+        "NumericValue": -100070,
+        "StringValue": "exclusion_complaint",
+        "VisibleInCoda": true
+      },
+      {
+        "MetaCode": "other",
+        "StringValue": "other",
+        "DisplayText": "meta: other",
+        "VisibleInCoda": false,
+        "NumericValue": -100110,
+        "CodeID": "code-O-7ce0d2a7",
+        "CodeType": "Meta"
+      },
+      {
+        "DisplayText": "meta: gratitude",
+        "VisibleInCoda": true,
+        "NumericValue": -100100,
+        "CodeID": "code-GR-e6de1b7e",
+        "CodeType": "Meta",
+        "MetaCode": "gratitude",
+        "StringValue": "gratitude"
+      },
+      {
+        "DisplayText": "meta: about conversation",
+        "VisibleInCoda": false,
+        "CodeID": "code-AC-9ed22631",
+        "NumericValue": -100120,
+        "CodeType": "Meta",
+        "MetaCode": "about_conversation",
+        "StringValue": "about_conversation"
+      },
+      {
+        "NumericValue": -100130,
+        "CodeID": "code-CR-8e99616b",
+        "CodeType": "Meta",
+        "MetaCode": "chasing_reply",
+        "StringValue": "chasing_reply",
+        "DisplayText": "meta: chasing reply",
+        "VisibleInCoda": false
+      }
+    ]
+}

--- a/code_schemes/facebook_s09e01.json
+++ b/code_schemes/facebook_s09e01.json
@@ -1,6 +1,6 @@
 {
     "SchemeID": "Scheme-a987cc0b",
-    "Name": "Facebook S01E01",
+    "Name": "Facebook S09E01",
     "Version": "0.0.0.1",
     "Codes": [
 

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -12,6 +12,10 @@ def _open_scheme(filename):
 class CodeSchemes(object):
     RQA_S09E01 = _open_scheme("rqa_s09e01.json")
 
+    FACEBOOK_S01E01 = _open_scheme("facebook_s01e01.json")
+    FACEBOOK_COMMENT_REPLY_TO = _open_scheme("facebook_comment_reply_to.json")
+    FACEBOOK_POST_TYPE = _open_scheme("facebook_post_type.json")
+
     SOMALIA_OPERATOR = _open_scheme("somalia_operator.json")
 
     AGE = _open_scheme("age.json")

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -12,7 +12,7 @@ def _open_scheme(filename):
 class CodeSchemes(object):
     RQA_S09E01 = _open_scheme("rqa_s09e01.json")
 
-    FACEBOOK_S01E01 = _open_scheme("facebook_s01e01.json")
+    FACEBOOK_S09E01 = _open_scheme("facebook_s09e01.json")
     FACEBOOK_COMMENT_REPLY_TO = _open_scheme("facebook_comment_reply_to.json")
     FACEBOOK_POST_TYPE = _open_scheme("facebook_post_type.json")
 

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -48,37 +48,37 @@ def clean_facebook_post_type(post):
 def get_rqa_coding_plans(pipeline_name):
     if pipeline_name == "TIS-Plus-Facebook":
         return [
-            CodingPlan(raw_field="facebook_s01e01_raw",
+            CodingPlan(raw_field="facebook_s09e01_raw",
                        time_field="sent_on",
-                       run_id_field="facebook_s01e01_run_id",
-                       coda_filename="TIS_Plus_facebook_s01e01.json",
-                       icr_filename="facebook_s01e01.csv",
+                       run_id_field="facebook_s09e01_run_id",
+                       coda_filename="TIS_Plus_facebook_s09e01.json",
+                       icr_filename="facebook_s09e01.csv",
                        coding_configurations=[
                            CodingConfiguration(
                                coding_mode=CodingModes.MULTIPLE,
-                               code_scheme=CodeSchemes.FACEBOOK_S01E01,
-                               coded_field="facebook_s01e01_coded",
-                               analysis_file_key="facebook_s01e01",
-                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S01E01, x, y)
+                               code_scheme=CodeSchemes.FACEBOOK_S09E01,
+                               coded_field="facebook_s09e01_coded",
+                               analysis_file_key="facebook_s09e01",
+                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S09E01, x, y)
                            ),
                            CodingConfiguration(
-                               raw_field="facebook_s01e01_comment_reply_to_raw",
+                               raw_field="facebook_s09e01_comment_reply_to_raw",
                                coding_mode=CodingModes.SINGLE,
                                code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
                                cleaner=lambda parent: "post" if parent == {} else "comment",
-                               coded_field="facebook_s01e01_comment_reply_to_coded",
+                               coded_field="facebook_s09e01_comment_reply_to_coded",
                                requires_manual_verification=False,
-                               analysis_file_key="facebook_s01e01_comment_reply_to",
+                               analysis_file_key="facebook_s09e01_comment_reply_to",
                                fold_strategy=None
                            ),
                            CodingConfiguration(
-                               raw_field="facebook_s01e01_post_raw",
+                               raw_field="facebook_s09e01_post_raw",
                                coding_mode=CodingModes.SINGLE,
                                code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
                                cleaner=clean_facebook_post_type,
-                               coded_field="facebook_s01e01_post_type_coded",
+                               coded_field="facebook_s09e01_post_type_coded",
                                requires_manual_verification=False,
-                               analysis_file_key="facebook_s01e01_post_type",
+                               analysis_file_key="facebook_s09e01_post_type",
                                fold_strategy=None
                            )
                        ],

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -46,8 +46,44 @@ def clean_facebook_post_type(post):
 
 
 def get_rqa_coding_plans(pipeline_name):
-    if pipeline_name == "Tis-Plus-Facebook":
-        assert False, "Not implemented"
+    if pipeline_name == "TIS-Plus-Facebook":
+        return [
+            CodingPlan(raw_field="facebook_s01e01_raw",
+                       time_field="sent_on",
+                       run_id_field="facebook_s01e01_run_id",
+                       coda_filename="TIS_Plus_facebook_s01e01.json",
+                       icr_filename="facebook_s01e01.csv",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.MULTIPLE,
+                               code_scheme=CodeSchemes.FACEBOOK_S01E01,
+                               coded_field="facebook_s01e01_coded",
+                               analysis_file_key="facebook_s01e01",
+                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.FACEBOOK_S01E01, x, y)
+                           ),
+                           CodingConfiguration(
+                               raw_field="facebook_s01e01_comment_reply_to_raw",
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.FACEBOOK_COMMENT_REPLY_TO,
+                               cleaner=lambda parent: "post" if parent == {} else "comment",
+                               coded_field="facebook_s01e01_comment_reply_to_coded",
+                               requires_manual_verification=False,
+                               analysis_file_key="facebook_s01e01_comment_reply_to",
+                               fold_strategy=None
+                           ),
+                           CodingConfiguration(
+                               raw_field="facebook_s01e01_post_raw",
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.FACEBOOK_POST_TYPE,
+                               cleaner=clean_facebook_post_type,
+                               coded_field="facebook_s01e01_post_type_coded",
+                               requires_manual_verification=False,
+                               analysis_file_key="facebook_s01e01_post_type",
+                               fold_strategy=None
+                           )
+                       ],
+                       raw_field_fold_strategy=FoldStrategies.concatenate)
+        ]
     else:
         assert pipeline_name == "TIS-Plus-SMS"
         return [
@@ -71,8 +107,8 @@ def get_rqa_coding_plans(pipeline_name):
 
 
 def get_demog_coding_plans(pipeline_name):
-    if pipeline_name == "Tis-Plus-Facebook":
-        assert False, "Not implemented"
+    if pipeline_name == "TIS-Plus-Facebook":
+        return []
     else:
         assert pipeline_name == "TIS-Plus-SMS"
         return [

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -3,33 +3,29 @@
   "RawDataSources": [
     {
       "SourceType": "Facebook",
-      "PageID": "abdullahiosmanfarah",
-      "TokenFileURL": "gs://avf-credentials/abdullahiosmanfarah-facebook-token.txt",
-      "Datasets": [
-        {"Name": "facebook_s01e01_abdullahiosmanfarah", "PostIDs": ["348455915581168_968057120287708"]}
-      ]
-    },
-    {
-      "SourceType": "Facebook",
       "PageID": "AbdirizakHAtosh",
       "TokenFileURL": "gs://avf-credentials/AbdirizakHAtosh-facebook-token.txt",
       "Datasets": [
-        {"Name": "facebook_s01e01_AbdirizakHAtosh", "PostIDs": ["1584334095169246_2750136618588982"]}
+        {"Name": "facebook_s09e01_AbdirizakHAtosh", "PostIDs": [
+          "1584334095169246_2777709599165017",
+          "1584334095169246_2777732125829431",
+          "1584334095169246_2777964775806166"
+        ]}
       ]
     }
   ],
   "SourceKeyRemappings": [
     {"SourceKey": "avf_facebook_id", "PipelineKey": "uid"},
 
-    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
-    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.parent", "PipelineKey": "facebook_s01e01_comment_reply_to_raw"},
-    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.post", "PipelineKey": "facebook_s01e01_post_raw"},
+    {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s09e01_raw"},
+    {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.parent", "PipelineKey": "facebook_s09e01_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.post", "PipelineKey": "facebook_s09e01_post_raw"},
 
-    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s01e01_raw"},
-    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
-    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.parent", "PipelineKey": "facebook_s01e01_comment_reply_to_raw"},
-    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.post", "PipelineKey": "facebook_s01e01_post_raw"}
+    {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s09e01_raw"},
+    {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.parent", "PipelineKey": "facebook_s09e01_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.post", "PipelineKey": "facebook_s09e01_post_raw"}
   ],
   "ProjectStartDate": "2000-01-01T00:00:00+03:00",
   "ProjectEndDate": "2100-01-01T00:00:00+03:00",

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -1,0 +1,53 @@
+{
+  "PipelineName": "TIS-Plus-Facebook",
+  "RawDataSources": [
+    {
+      "SourceType": "Facebook",
+      "PageID": "abdullahiosmanfarah",
+      "TokenFileURL": "gs://avf-credentials/abdullahiosmanfarah-facebook-token.txt",
+      "Datasets": [
+        {"Name": "facebook_s01e01_abdullahiosmanfarah", "PostIDs": ["348455915581168_968057120287708"]}
+      ]
+    },
+    {
+      "SourceType": "Facebook",
+      "PageID": "AbdirizakHAtosh",
+      "TokenFileURL": "gs://avf-credentials/AbdirizakHAtosh-facebook-token.txt",
+      "Datasets": [
+        {"Name": "facebook_s01e01_AbdirizakHAtosh", "PostIDs": ["1584334095169246_2750136618588982"]}
+      ]
+    }
+  ],
+  "SourceKeyRemappings": [
+    {"SourceKey": "avf_facebook_id", "PipelineKey": "uid"},
+
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.parent", "PipelineKey": "facebook_s01e01_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s01e01_abdullahiosmanfarah.post", "PipelineKey": "facebook_s01e01_post_raw"},
+
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s01e01_raw"},
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.parent", "PipelineKey": "facebook_s01e01_comment_reply_to_raw"},
+    {"SourceKey": "facebook_s01e01_AbdirizakHAtosh.post", "PipelineKey": "facebook_s01e01_post_raw"}
+  ],
+  "ProjectStartDate": "2000-01-01T00:00:00+03:00",
+  "ProjectEndDate": "2100-01-01T00:00:00+03:00",
+  "FilterTestMessages": false,
+  "MoveWSMessages": false,
+  "AutomatedAnalysis": {
+    "GenerateRegionThemeDistributionMaps": false,
+    "GenerateDistrictThemeDistributionMaps": false,
+    "GenerateMogadishuThemeDistributionMaps": false
+  },
+  "DriveUpload": {
+    "DriveCredentialsFileURL": "gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
+    "ProductionUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_production.csv",
+    "MessagesUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_messages.csv",
+    "IndividualsUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_individuals.csv",
+    "AutomatedAnalysisDir": "usaid_ibtci_analysis_outputs/facebook/automated_analysis"
+  },
+  "MemoryProfileUploadBucket":"gs://avf-pipeline-logs-performance-nearline",
+  "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
+  "BucketDirPath": "2020/USAID-IBTCI/Facebook/"
+}

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -38,12 +38,12 @@
   },
   "DriveUpload": {
     "DriveCredentialsFileURL": "gs://avf-credentials/pipeline-runner-service-acct-avf-data-core-64cc71459fe7.json",
-    "ProductionUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_production.csv",
-    "MessagesUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_messages.csv",
-    "IndividualsUploadPath": "usaid_ibtci_analysis_outputs/facebook/usaid_ibtci_facebook_individuals.csv",
-    "AutomatedAnalysisDir": "usaid_ibtci_analysis_outputs/facebook/automated_analysis"
+    "ProductionUploadPath": "tis_plus_analysis_outputs/facebook/tis_plus_facebook_production.csv",
+    "MessagesUploadPath": "tis_plus_analysis_outputs/facebook/tis_plus_facebook_messages.csv",
+    "IndividualsUploadPath": "tis_plus_analysis_outputs/facebook/tis_plus_facebook_individuals.csv",
+    "AutomatedAnalysisDir": "tis_plus_analysis_outputs/facebook/automated_analysis"
   },
   "MemoryProfileUploadBucket":"gs://avf-pipeline-logs-performance-nearline",
   "DataArchiveUploadBucket": "gs://pipeline-execution-backup-archive",
-  "BucketDirPath": "2020/USAID-IBTCI/Facebook/"
+  "BucketDirPath": "2020/TIS-Plus/Facebook/"
 }

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -212,16 +212,16 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
         for post_id in dataset.post_ids:
             comments_log_path = f"{raw_data_dir}/{post_id}_comments_log.jsonl"
             with open(comments_log_path, "a") as raw_comments_log_file:
-                raw_comments.extend(
-                    facebook.get_all_comments_on_post(post_id, raw_export_log_file=raw_comments_log_file)
-                )
+                post_comments = facebook.get_all_comments_on_post(post_id, raw_export_log_file=raw_comments_log_file)
 
             # Download the post and add it as context to all the comments. Adding a reference to the post under
             # which a comment was made enables downstream features such as post-type labelling and comment context
             # in Coda, as well as allowing us to track how many comments were made on each post.
             post = facebook.get_post(post_id, fields=["attachments"])
-            for comment in raw_comments:
+            for comment in post_comments:
                 comment["post"] = post
+
+            raw_comments.extend(post_comments)
 
         # Facebook only returns a parent if the comment is a reply to another comment.
         # If there is no parent, set one to the empty-dict.

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -17,6 +17,8 @@ DATA_ROOT=$3
 DATASETS=(
     "TIS_Plus_rqa_s09e01"
 
+    "TIS_Plus_facebook_s09e01"
+
     "CSAP_age"
     "CSAP_gender"
     "CSAP_location"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -17,6 +17,8 @@ DATA_ROOT=$3
 DATASETS=(
     "TIS_Plus_rqa_s09e01"
 
+    "TIS_Plus_facebook_s09e01"
+
     "CSAP_age"
     "CSAP_gender"
     "CSAP_location"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -31,7 +31,10 @@ git checkout "e895887b3abceb63bab672a262d5c1dd73dcad92"  # (master which support
 
 for DATASET in ${DATASETS[@]}
 do
-    echo "Pushing messages data to ${DATASET}..."
+    FILE="$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
 
-    pipenv run python add.py "$AUTH" "${DATASET}" messages "$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
+    if [ -e "$FILE" ]; then
+        echo "Pushing messages data to ${DATASET}..."
+        pipenv run python add.py "$AUTH" "${DATASET}" messages "$FILE"
+    fi
 done

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -33,7 +33,7 @@ for DATASET in ${DATASETS[@]}
 do
     FILE="$DATA_ROOT/Outputs/Coda Files/$DATASET.json"
 
-    if [ -e "$FILE" ]; then
+    if [ -e "$FILE" ]; then  # Stop-gap workaround for supporting multiple pipelines until we have a Coda library
         echo "Pushing messages data to ${DATASET}..."
         pipenv run python add.py "$AUTH" "${DATASET}" messages "$FILE"
     fi

--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -144,6 +144,9 @@ class AnalysisUtils(object):
         """
         if cls.withdrew_consent(td, consent_withdrawn_key):
             return False
+
+        if not cls.labelled(td, consent_withdrawn_key, coding_plan):
+            return False
         
         for cc in coding_plan.coding_configurations:
             codes = cls._get_td_codes_for_coding_configuration(td, cc)

--- a/upload_analysis_files.py
+++ b/upload_analysis_files.py
@@ -78,12 +78,15 @@ if __name__ == "__main__":
                                                   target_folder_is_shared_with_me=True, recursive=True,
                                                   fix_duplicates=True)
 
-            individuals_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.individuals_upload_path)
-            individuals_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.individuals_upload_path)
-            drive_client_wrapper.update_or_create(individuals_csv_input_path, individuals_csv_drive_dir,
-                                                  target_file_name=individuals_csv_drive_file_name,
-                                                  target_folder_is_shared_with_me=True, recursive=True,
-                                                  fix_duplicates=True)
+            if pipeline_configuration.pipeline_name != "TIS-Plus-Facebook":
+                # Don't upload the individuals file until we have access to user ids from Facebook, so as not to
+                # confuse the RAs
+                individuals_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.individuals_upload_path)
+                individuals_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.individuals_upload_path)
+                drive_client_wrapper.update_or_create(individuals_csv_input_path, individuals_csv_drive_dir,
+                                                      target_file_name=individuals_csv_drive_file_name,
+                                                      target_folder_is_shared_with_me=True, recursive=True,
+                                                      fix_duplicates=True)
 
             paths_to_upload = glob(f"{automated_analysis_input_dir}/*.csv")
             log.info(f"Uploading {len(paths_to_upload)} CSVs to Drive...")


### PR DESCRIPTION
Adds Facebook configuration for e01, adapted from the configuration for IBTCI with the following bug fixes/modifications:
- Disables most of automated analysis for the Facebook pipeline until we learn what makes sense, what we need and how to adapt from the sms automated analysis.
- Fixes a bug in fetch_raw_data that was causing comments to mis-labelled with the wrong posts.
- Fixes the definition of relevant to force it to be a subset of labelled.
- Disables upload of the individuals file, because it doesn't make sense until we have user ids.

Also note:
- We're missing the posts from one of the pages to an authentication error.
- The meta codes in the thematic code scheme are included here to make the pipeline work, but this scheme is not yet in coda and the meta codes may change after reviewing them.