### PR TITLE
Fix coda id collisions when providing context

### DIFF
--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -1,5 +1,6 @@
 from core_data_modules.cleaners import somali, swahili, Codes
 from core_data_modules.traced_data.util.fold_traced_data import FoldStrategies
+from core_data_modules.util import SHAUtils
 
 from configuration import code_imputation_functions
 from configuration.code_schemes import CodeSchemes
@@ -52,6 +53,7 @@ def get_rqa_coding_plans(pipeline_name):
                        time_field="sent_on",
                        run_id_field="facebook_s09e01_run_id",
                        coda_filename="TIS_Plus_facebook_s09e01.json",
+                       message_id_fn=lambda td: SHAUtils.sha_string(td["facebook_s09e01_comment_id"]),
                        icr_filename="facebook_s09e01.csv",
                        coding_configurations=[
                            CodingConfiguration(
@@ -88,6 +90,7 @@ def get_rqa_coding_plans(pipeline_name):
                        time_field="sent_on",
                        run_id_field="facebook_s09e02_run_id",
                        coda_filename="TIS_Plus_facebook_s09e02.json",
+                       message_id_fn=lambda td: SHAUtils.sha_string(td["facebook_s09e02_comment_id"]),
                        icr_filename="facebook_s09e02.csv",
                        coding_configurations=[
                            CodingConfiguration(

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -23,16 +23,19 @@
     {"SourceKey": "avf_facebook_id", "PipelineKey": "uid"},
 
     {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.message", "PipelineKey": "facebook_s09e01_raw"},
+    {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.id", "PipelineKey": "facebook_s09e01_comment_id"},
     {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.parent", "PipelineKey": "facebook_s09e01_comment_reply_to_raw"},
     {"SourceKey": "facebook_s09e01_abdullahiosmanfarah.post", "PipelineKey": "facebook_s09e01_post_raw"},
 
     {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.message", "PipelineKey": "facebook_s09e01_raw"},
+    {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.id", "PipelineKey": "facebook_s09e01_comment_id"},
     {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.parent", "PipelineKey": "facebook_s09e01_comment_reply_to_raw"},
     {"SourceKey": "facebook_s09e01_AbdirizakHAtosh.post", "PipelineKey": "facebook_s09e01_post_raw"},
     
     {"SourceKey": "facebook_s09e02_AbdirizakHAtosh.message", "PipelineKey": "facebook_s09e02_raw"},
+    {"SourceKey": "facebook_s09e02_AbdirizakHAtosh.id", "PipelineKey": "facebook_s09e02_comment_id"},
     {"SourceKey": "facebook_s09e02_AbdirizakHAtosh.created_time", "PipelineKey": "sent_on"},
     {"SourceKey": "facebook_s09e02_AbdirizakHAtosh.parent", "PipelineKey": "facebook_s09e02_comment_reply_to_raw"},
     {"SourceKey": "facebook_s09e02_AbdirizakHAtosh.post", "PipelineKey": "facebook_s09e02_post_raw"}

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -1,3 +1,6 @@
+from core_data_modules.util import SHAUtils
+
+
 class CodingModes(object):
     SINGLE = "SINGLE"
     MULTIPLE = "MULTIPLE"
@@ -20,10 +23,13 @@ class CodingConfiguration(object):
         self.include_in_theme_distribution = include_in_theme_distribution
 
 
-# TODO: Rename CodingPlan to something like DatasetConfiguration?
 class CodingPlan(object):
     def __init__(self, raw_field, coding_configurations, raw_field_fold_strategy, coda_filename=None, ws_code=None,
-                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None):
+                 time_field=None, run_id_field=None, icr_filename=None, id_field=None, code_imputation_function=None,
+                 message_id_fn=None):
+        if message_id_fn is None:
+            message_id_fn = lambda td: SHAUtils.sha_string(td[self.raw_field])
+
         self.raw_field = raw_field
         self.time_field = time_field
         self.run_id_field = run_id_field
@@ -34,6 +40,7 @@ class CodingPlan(object):
         self.ws_code = ws_code
         self.raw_field_fold_strategy = raw_field_fold_strategy
         self.dataset_name = raw_field
+        self.message_id_fn = message_id_fn
 
         if id_field is None:
             id_field = f"{self.raw_field}_id"

--- a/src/ws_correction.py
+++ b/src/ws_correction.py
@@ -5,6 +5,7 @@ from core_data_modules.cleaners.cleaning_utils import CleaningUtils
 from core_data_modules.logging import Logger
 from core_data_modules.traced_data import Metadata
 from core_data_modules.traced_data.io import TracedDataCodaV2IO
+from core_data_modules.util import TimeUtils
 
 from src.lib import PipelineConfiguration
 from src.lib.configuration_objects import CodingModes
@@ -28,7 +29,13 @@ class WSCorrection(object):
             if plan.coda_filename is None:
                 continue
 
-            TracedDataCodaV2IO.compute_message_ids(user, data, plan.raw_field, f"{plan.id_field}_WS")
+            for td in data:
+                if plan.raw_field in td:
+                    td.append_data(
+                        {f"{plan.id_field}_WS": plan.message_id_fn(td)},
+                        Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())
+                    )
+
             with open(f"{coda_input_dir}/{plan.coda_filename}") as f:
                 TracedDataCodaV2IO.import_coda_2_to_traced_data_iterable(
                     user, data, f"{plan.id_field}_WS",


### PR DESCRIPTION
We provided context in Coda for the Facebook datasets to assist with labelling (facebook post type and comment reply to). The problem with this is we might see the same message in different comments, so the context is different each time we see it e.g. the comment reply to might be to a post in one place but to another comment somewhere else. This means we're trying to label the same comment text, and therefore the same MessageID in Coda, with different labels, causing the pipeline to fail.

This PR addresses this by deriving the MessageID for the facebook comments from the comment id rather than from the text content, ensuring no collisions. The drawback of this approach is that the same message may need to be labelled multiple times, including when the context is the same, but I think that's acceptable because (a) it buys us more flexibility rather than needing to commit to what 'context' is now', and (b) this is rqa-like data rather than demogs, so the number of duplicate messages should actually be quite low. The main caveat is that labelling has started, so we'll need to migrate the existing labels over to the new ids and rewrite the dataset in Coda.