### PR TITLE
Support mid-season break

### DIFF
--- a/code_schemes/rqa_s09e03_break.json
+++ b/code_schemes/rqa_s09e03_break.json
@@ -1,0 +1,179 @@
+{
+  "SchemeID": "Scheme-0ada833b",
+  "Name": "RQA S09E03 Break",
+  "Version": "0.0.0.1",
+  "Codes": [
+
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    },
+    {
+      "DisplayText": "meta: gratitude",
+      "VisibleInCoda": true,
+      "NumericValue": -100100,
+      "CodeID": "code-GR-e6de1b7e",
+      "CodeType": "Meta",
+      "MetaCode": "gratitude",
+      "StringValue": "gratitude"
+    },
+    {
+      "NumericValue": -100130,
+      "CodeID": "code-CR-8e99616b",
+      "CodeType": "Meta",
+      "MetaCode": "chasing_reply",
+      "StringValue": "chasing_reply",
+      "DisplayText": "meta: chasing reply",
+      "VisibleInCoda": true
+    },
+    {
+      "NumericValue": -100140,
+      "CodeID": "code-I-b13a41f6",
+      "CodeType": "Meta",
+      "MetaCode": "impact",
+      "StringValue": "impact",
+      "DisplayText": "meta: impact",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/code_schemes/ws_correct_dataset.json
+++ b/code_schemes/ws_correct_dataset.json
@@ -37,6 +37,17 @@
       ]
     },
     {
+      "CodeID": "code-1fe18580",
+      "CodeType": "Normal",
+      "DisplayText": "s09e03 break",
+      "StringValue": "s09e03_break",
+      "NumericValue": 45,
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "s09e03 break"
+      ]
+    },
+    {
       "CodeID": "code-70ac05ab",
       "CodeType": "Normal",
       "DisplayText": "age",

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -13,6 +13,7 @@ class CodeSchemes(object):
     RQA_S09E01 = _open_scheme("rqa_s09e01.json")
     RQA_S09E02 = _open_scheme("rqa_s09e02.json")
     RQA_S09E03 = _open_scheme("rqa_s09e03.json")
+    RQA_S09E03_BREAK = _open_scheme("rqa_s09e03_break.json")
 
     FACEBOOK_S09E01 = _open_scheme("facebook_s09e01.json")
     FACEBOOK_S09E02 = _open_scheme("facebook_s09e02.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -166,7 +166,7 @@ def get_rqa_coding_plans(pipeline_name):
         return [
             CodingPlan(raw_field="rqa_s09e01_raw",
                        time_field="sent_on",
-                       run_id_field="rqa_s08e01_run_id",
+                       run_id_field="rqa_s09e01_run_id",
                        coda_filename="TIS_Plus_rqa_s09e01.json",
                        icr_filename="rqa_s09e01.csv",
                        coding_configurations=[
@@ -183,7 +183,7 @@ def get_rqa_coding_plans(pipeline_name):
 
             CodingPlan(raw_field="rqa_s09e02_raw",
                        time_field="sent_on",
-                       run_id_field="rqa_s08e02_run_id",
+                       run_id_field="rqa_s09e02_run_id",
                        coda_filename="TIS_Plus_rqa_s09e02.json",
                        icr_filename="rqa_s09e02.csv",
                        coding_configurations=[
@@ -200,7 +200,7 @@ def get_rqa_coding_plans(pipeline_name):
 
             CodingPlan(raw_field="rqa_s09e03_raw",
                        time_field="sent_on",
-                       run_id_field="rqa_s08e03_run_id",
+                       run_id_field="rqa_s09e03_run_id",
                        coda_filename="TIS_Plus_rqa_s09e03.json",
                        icr_filename="rqa_s09e03.csv",
                        coding_configurations=[
@@ -214,6 +214,23 @@ def get_rqa_coding_plans(pipeline_name):
                        ],
                        ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s09e03"),
                        raw_field_fold_strategy=FoldStrategies.concatenate),
+
+            CodingPlan(raw_field="rqa_s09e03_break_raw",
+                       time_field="sent_on",
+                       run_id_field="rqa_s09e03_break_run_id",
+                       coda_filename="TIS_Plus_rqa_s09e03_break.json",
+                       icr_filename="rqa_s09e03_break.csv",
+                       coding_configurations=[
+                           CodingConfiguration(
+                               coding_mode=CodingModes.MULTIPLE,
+                               code_scheme=CodeSchemes.RQA_S09E03_BREAK,
+                               coded_field="rqa_s09e03_break_coded",
+                               analysis_file_key="rqa_s09e03_break",
+                               fold_strategy=lambda x, y: FoldStrategies.list_of_labels(CodeSchemes.RQA_S09E03_BREAK, x, y)
+                           )
+                       ],
+                       ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("s09e03 break"),
+                       raw_field_fold_strategy=FoldStrategies.concatenate)
         ]
 
 

--- a/configuration/sms_pipeline_config.json
+++ b/configuration/sms_pipeline_config.json
@@ -9,7 +9,8 @@
       "ActivationFlowNames": [
         "csap_s09e01_activation",
         "csap_s09e02_activation",
-        "csap_s09e03_activation"
+        "csap_s09e03_activation",
+        "csap_s09e03_break_activation"
       ],
       "SurveyFlowNames": [
         "csap_demog",
@@ -65,6 +66,10 @@
     {"SourceKey": "Rqa_S09E03 (Text) - csap_s09e03_activation", "PipelineKey": "rqa_s09e03_raw", "IsActivationMessage": true},
     {"SourceKey": "Rqa_S09E03 (Run ID) - csap_s09e03_activation", "PipelineKey": "rqa_s09e03_run_id"},
     {"SourceKey": "Rqa_S09E03 (Time) - csap_s09e03_activation", "PipelineKey": "sent_on"},
+
+    {"SourceKey": "Rqa_S09E03_Break (Text) - csap_s09e03_break_activation", "PipelineKey": "rqa_s09e03_break_raw", "IsActivationMessage": true},
+    {"SourceKey": "Rqa_S09E03_Break (Run ID) - csap_s09e03_break_activation", "PipelineKey": "rqa_s09e03_break_run_id"},
+    {"SourceKey": "Rqa_S09E03_Break (Time) - csap_s09e03_break_activation", "PipelineKey": "sent_on"},
 
     {"SourceKey": "Mog_Sub_District (Text) - csap_demog", "PipelineKey": "location_raw"},
     {"SourceKey": "Mog_Sub_District (Time) - csap_demog", "PipelineKey": "location_time"},

--- a/configuration/sms_pipeline_config.json
+++ b/configuration/sms_pipeline_config.json
@@ -52,6 +52,14 @@
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
     "TableName": "ADSS"
   },
+  "TimestampRemappings": [
+    {
+      "TimeKey": "Rqa_S09E03 (Time) - csap_s09e03_activation",
+      "ShowPipelineKeyToRemapTo": "rqa_s09e03_break_raw",
+      "RangeStartInclusive": "2020-11-02T00:00:00+03:00",
+      "RangeEndExclusive": "2020-11-05T24:00:00+03:00"
+    }
+  ],
   "SourceKeyRemappings": [
     {"SourceKey": "avf_phone_id", "PipelineKey": "uid"},
 

--- a/run_scripts/1_coda_get.sh
+++ b/run_scripts/1_coda_get.sh
@@ -18,6 +18,7 @@ DATASETS=(
     "TIS_Plus_rqa_s09e01"
     "TIS_Plus_rqa_s09e02"
     "TIS_Plus_rqa_s09e03"
+    "TIS_Plus_rqa_s09e03_break"
 
     "TIS_Plus_facebook_s09e01"
     "TIS_Plus_facebook_s09e02"

--- a/run_scripts/4_coda_add.sh
+++ b/run_scripts/4_coda_add.sh
@@ -18,6 +18,7 @@ DATASETS=(
     "TIS_Plus_rqa_s09e01"
     "TIS_Plus_rqa_s09e02"
     "TIS_Plus_rqa_s09e03"
+    "TIS_Plus_rqa_s09e03_break"
 
     "TIS_Plus_facebook_s09e01"
     "TIS_Plus_facebook_s09e02"

--- a/src/translate_source_keys.py
+++ b/src/translate_source_keys.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 
 import pytz
@@ -32,7 +33,7 @@ class TranslateSourceKeys(object):
                 if not remapping.is_activation_message:
                     continue
 
-                if td.get(remapping.source_key) is not None:
+                if remapping.source_key in td:
                     assert "rqa_message" not in show_dict
                     show_dict["rqa_message"] = td[remapping.source_key]
                     show_dict["show_pipeline_key"] = remapping.pipeline_key


### PR DESCRIPTION
TIS+ is on a 3 week break in its radio programming. This PR updates to support collecting messages and uploading to Coda (and analysing in Coda if we eventually choose to do so), in a separate dataset. It's in a separate dataset so as not to affect the participation numbers/relevance rate for e03. Mostly this is standard, we just treat this as a new activation flow called e03_break (with reference to e03 so it's easy to see when the break occurred, and to distinguish breaks if we have a project that has multiple).

The main place to draw attention to is the timestamp remapping: We changed the activation flow a few days too late so are retroactively moving messages from the first few days of the break from e03 -> e03_break. I think this is the first time we've used the timestamp remapping function since OCHA.