### PR TITLE
Categorise age

### DIFF
--- a/automated_analysis.py
+++ b/automated_analysis.py
@@ -187,7 +187,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.include_in_theme_distribution == Codes.FALSE:
+                if not cc.include_in_theme_distribution:
                     continue
 
                 code = cc.code_scheme.get_code_with_code_id(ind[cc.coded_field]["CodeID"])
@@ -219,7 +219,7 @@ if __name__ == "__main__":
         survey_counts["Total Participants %"] = None
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.include_in_theme_distribution == Codes.FALSE:
+                if not cc.include_in_theme_distribution:
                     continue
 
                 for code in cc.code_scheme.codes:
@@ -233,7 +233,7 @@ if __name__ == "__main__":
     def update_survey_counts(survey_counts, td):
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.include_in_theme_distribution == Codes.FALSE:
+                if not cc.include_in_theme_distribution:
                     continue
 
                 if cc.coding_mode == CodingModes.SINGLE:
@@ -256,7 +256,7 @@ if __name__ == "__main__":
 
         for plan in PipelineConfiguration.SURVEY_CODING_PLANS:
             for cc in plan.coding_configurations:
-                if cc.include_in_theme_distribution == Codes.FALSE:
+                if not cc.include_in_theme_distribution:
                     continue
 
                 for code in cc.code_scheme.codes:

--- a/code_schemes/age_category.json
+++ b/code_schemes/age_category.json
@@ -1,0 +1,216 @@
+{
+  "SchemeID": "Scheme-eea1ce89",
+  "Name": "Age Category",
+  "Version": "0.0.0.1",
+  "Codes": [
+    {
+      "CodeID": "code-E-720cdb66",
+      "CodeType": "Meta",
+      "MetaCode": "escalate",
+      "DisplayText": "meta: ESCALATE",
+      "NumericValue": -100080,
+      "StringValue": "escalate",
+      "VisibleInCoda": true,
+      "Shortcut": "e"
+    },
+    {
+      "CodeID": "code-aa2640e7",
+      "CodeType": "Normal",
+      "DisplayText": "10 to 14",
+      "NumericValue": 1,
+      "StringValue": "10_to_14",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "10 to 14"
+      ]
+    },
+    {
+      "CodeID": "code-57391e8f",
+      "CodeType": "Normal",
+      "DisplayText": "15 to 17",
+      "NumericValue": 2,
+      "StringValue": "15_to_17",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "15 to 17"
+      ]
+    },
+    {
+      "CodeID": "code-ef3c9330",
+      "CodeType": "Normal",
+      "DisplayText": "18 to 35",
+      "NumericValue": 3,
+      "StringValue": "18_to_35",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "18 to 35"
+      ]
+    },
+    {
+      "CodeID": "code-494d7659",
+      "CodeType": "Normal",
+      "DisplayText": "36 to 54",
+      "NumericValue": 4,
+      "StringValue": "36_to_54",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "36 to 54"
+      ]
+    },
+    {
+      "CodeID": "code-968879ef",
+      "CodeType": "Normal",
+      "DisplayText": "55 to 99",
+      "NumericValue": 5,
+      "StringValue": "55_to_99",
+      "VisibleInCoda": true,
+      "MatchValues": [
+        "55 to 99"
+      ]
+    },
+    {
+      "CodeID": "code-NA-f93d3eb7",
+      "CodeType": "Control",
+      "ControlCode": "NA",
+      "DisplayText": "NA (missing)",
+      "NumericValue": -10,
+      "StringValue": "NA",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NS-2c11b7c9",
+      "CodeType": "Control",
+      "ControlCode": "NS",
+      "DisplayText": "NS (skip)",
+      "NumericValue": -20,
+      "StringValue": "NS",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NC-42f1d983",
+      "CodeType": "Control",
+      "ControlCode": "NC",
+      "DisplayText": "NC (not coded)",
+      "NumericValue": -30,
+      "StringValue": "NC",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-NR-5e3eee23",
+      "CodeType": "Control",
+      "ControlCode": "NR",
+      "DisplayText": "NR (not reviewed)",
+      "NumericValue": -40,
+      "StringValue": "NR",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-NIC-99631cb8",
+      "CodeType": "Control",
+      "ControlCode": "NIC",
+      "DisplayText": "NIC (not internally consistent)",
+      "NumericValue": -50,
+      "StringValue": "NIC",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-STOP-08b832a8",
+      "CodeType": "Control",
+      "ControlCode": "STOP",
+      "DisplayText": "STOP",
+      "NumericValue": -90,
+      "StringValue": "STOP",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-WS-adb25603b7af",
+      "CodeType": "Control",
+      "ControlCode": "WS",
+      "DisplayText": "WS (wrong scheme)",
+      "NumericValue": -100,
+      "StringValue": "WS",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-CE-016c1e22",
+      "CodeType": "Control",
+      "ControlCode": "CE",
+      "DisplayText": "CE (coding error)",
+      "NumericValue": -110,
+      "StringValue": "CE",
+      "VisibleInCoda": false
+    },
+    {
+      "CodeID": "code-PB-a434a800",
+      "CodeType": "Meta",
+      "MetaCode": "push_back",
+      "DisplayText": "meta: push back",
+      "NumericValue": -100000,
+      "StringValue": "push_back",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SQ-5e8f0122",
+      "CodeType": "Meta",
+      "MetaCode": "showtime_question",
+      "DisplayText": "meta: showtime question",
+      "NumericValue": -100030,
+      "StringValue": "showtime_question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-Q-a5d3700d",
+      "CodeType": "Meta",
+      "MetaCode": "question",
+      "DisplayText": "meta: question",
+      "NumericValue": -100010,
+      "StringValue": "question",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-G-97cb3199",
+      "CodeType": "Meta",
+      "MetaCode": "greeting",
+      "DisplayText": "meta: greeting",
+      "NumericValue": -100020,
+      "StringValue": "greeting",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-OI-c5f1d054",
+      "CodeType": "Meta",
+      "MetaCode": "opt_in",
+      "DisplayText": "meta: opt-in",
+      "NumericValue": -100040,
+      "StringValue": "opt_in",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-SC-a3a065bc",
+      "CodeType": "Meta",
+      "MetaCode": "similar_content",
+      "DisplayText": "meta: similar content",
+      "NumericValue": -100050,
+      "StringValue": "similar_content",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-PI-83b90d32",
+      "CodeType": "Meta",
+      "MetaCode": "participation_incentive",
+      "DisplayText": "meta: participation incentive",
+      "NumericValue": -100060,
+      "StringValue": "participation_incentive",
+      "VisibleInCoda": true
+    },
+    {
+      "CodeID": "code-EC-3a704f5b",
+      "CodeType": "Meta",
+      "MetaCode": "exclusion_complaint",
+      "DisplayText": "meta: exclusion complaint",
+      "NumericValue": -100070,
+      "StringValue": "exclusion_complaint",
+      "VisibleInCoda": true
+    }
+  ]
+}

--- a/configuration/code_schemes.py
+++ b/configuration/code_schemes.py
@@ -24,6 +24,7 @@ class CodeSchemes(object):
     SOMALIA_OPERATOR = _open_scheme("somalia_operator.json")
 
     AGE = _open_scheme("age.json")
+    AGE_CATEGORY = _open_scheme("age_category.json")
     GENDER = _open_scheme("gender.json")
     MOGADISHU_SUB_DISTRICT = _open_scheme("mogadishu_sub_district.json")
     SOMALIA_DISTRICT = _open_scheme("somalia_district.json")

--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -324,17 +324,18 @@ def get_demog_coding_plans(pipeline_name):
                                cleaner=clean_age_with_range_filter,
                                coded_field="age_coded",
                                analysis_file_key="age",
+                               include_in_theme_distribution=False,
+                               fold_strategy=FoldStrategies.assert_label_ids_equal
+                           ),
+                           CodingConfiguration(
+                               coding_mode=CodingModes.SINGLE,
+                               code_scheme=CodeSchemes.AGE_CATEGORY,
+                               coded_field="age_category_coded",
+                               analysis_file_key="age_category",
                                fold_strategy=FoldStrategies.assert_label_ids_equal
                            )
-                           # CodingConfiguration(
-                           #     coding_mode=CodingModes.SINGLE,
-                           #     code_scheme=CodeSchemes.AGE_CATEGORY,
-                           #     coded_field="age_category_coded",
-                           #     analysis_file_key="age_category",
-                           #     fold_strategy=FoldStrategies.assert_label_ids_equal
-                           # )
                        ],
-                       # code_imputation_function=code_imputation_functions.impute_age_category,
+                       code_imputation_function=code_imputation_functions.impute_age_category,
                        ws_code=CodeSchemes.WS_CORRECT_DATASET.get_code_with_match_value("age"),
                        raw_field_fold_strategy=FoldStrategies.assert_equal),
 

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -9,7 +9,7 @@ class CodingModes(object):
 class CodingConfiguration(object):
     def __init__(self, coding_mode, code_scheme, coded_field, fold_strategy, raw_field=None,
                  requires_manual_verification=True, analysis_file_key=None, cleaner=None,
-                 include_in_theme_distribution=False):
+                 include_in_theme_distribution=True):
         assert coding_mode in {CodingModes.SINGLE, CodingModes.MULTIPLE}
 
         self.coding_mode = coding_mode


### PR DESCRIPTION
Uses standard categories and code scheme from other CSAP projects, updated to synchronise with TIS+'s current meta codes. Corrects include_in_theme_distributions to be of type boolean rather than Code