### PR TITLE
Use Facebook user ids in the individuals file

### DIFF
--- a/configuration/coding_plans.py
+++ b/configuration/coding_plans.py
@@ -71,7 +71,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e01_comment_reply_to_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e01_comment_reply_to",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            ),
                            CodingConfiguration(
                                raw_field="facebook_s09e01_post_raw",
@@ -81,7 +82,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e01_post_type_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e01_post_type",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            )
                        ],
                        raw_field_fold_strategy=FoldStrategies.concatenate),
@@ -108,7 +110,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e02_comment_reply_to_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e02_comment_reply_to",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            ),
                            CodingConfiguration(
                                raw_field="facebook_s09e02_post_raw",
@@ -118,7 +121,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e02_post_type_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e02_post_type",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            )
                        ],
                        raw_field_fold_strategy=FoldStrategies.concatenate),
@@ -146,7 +150,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e03_comment_reply_to_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e03_comment_reply_to",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            ),
                            CodingConfiguration(
                                raw_field="facebook_s09e03_post_raw",
@@ -156,7 +161,8 @@ def get_rqa_coding_plans(pipeline_name):
                                coded_field="facebook_s09e03_post_type_coded",
                                requires_manual_verification=False,
                                analysis_file_key="facebook_s09e03_post_type",
-                               fold_strategy=None
+                               fold_strategy=None,
+                               include_in_individuals_file=False
                            )
                        ],
                        raw_field_fold_strategy=FoldStrategies.concatenate)

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -39,6 +39,11 @@
       ]
     }
   ],
+  "UuidTable": {
+    "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
+    "TableName": "TIS-Plus-Facebook-Test",
+    "UuidPrefix": "avf-facebook-uuid-"
+  },
   "SourceKeyRemappings": [
     {"SourceKey": "avf_facebook_id", "PipelineKey": "uid"},
 

--- a/configuration/facebook_pipeline_config.json
+++ b/configuration/facebook_pipeline_config.json
@@ -41,7 +41,7 @@
   ],
   "UuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
-    "TableName": "TIS-Plus-Facebook-Test",
+    "TableName": "TIS_Plus_facebook_avf_facebook_id",
     "UuidPrefix": "avf-facebook-uuid-"
   },
   "SourceKeyRemappings": [

--- a/configuration/sms_pipeline_config.json
+++ b/configuration/sms_pipeline_config.json
@@ -48,9 +48,10 @@
       ]
     }
   ],
-  "PhoneNumberUuidTable": {
+  "UuidTable": {
     "FirebaseCredentialsFileURL": "gs://avf-credentials/avf-id-infrastructure-firebase-adminsdk-6xps8-b9173f2bfd.json",
-    "TableName": "ADSS"
+    "TableName": "ADSS",
+    "UuidPrefix": "avf-phone-uuid-"
   },
   "TimestampRemappings": [
     {

--- a/export_weekly_ad_contacts.py
+++ b/export_weekly_ad_contacts.py
@@ -44,11 +44,11 @@ if __name__ == "__main__":
     log.info("Downloading Firestore UUID Table credentials...")
     firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
         google_cloud_credentials_file_path,
-        pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
+        pipeline_configuration.uuid_table.firebase_credentials_file_url
     ))
 
     phone_number_uuid_table = FirestoreUuidTable(
-        pipeline_configuration.phone_number_uuid_table.table_name,
+        pipeline_configuration.uuid_table.table_name,
         firestore_uuid_table_credentials,
         "avf-phone-uuid-"
     )

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -194,7 +194,7 @@ def fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_d
         log.info(f"Exported TracedData")
 
 
-def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, facebook_source):
+def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table, facebook_source):
     log.info("Fetching data from Facebook...")
     log.info("Downloading Facebook access token...")
     facebook_token = google_cloud_utils.download_blob_to_string(
@@ -233,7 +233,8 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
                 comment["parent"] = {}
 
         # Convert the comments to TracedData.
-        traced_comments = facebook.convert_facebook_comments_to_traced_data(user, dataset.name, raw_comments)
+        traced_comments = facebook.convert_facebook_comments_to_traced_data(
+            user, dataset.name, raw_comments, phone_number_uuid_table)
 
         # Export to disk.
         log.info(f"Saving {len(raw_comments)} raw comments to {raw_comments_output_path}...")
@@ -257,33 +258,33 @@ def main(user, google_cloud_credentials_file_path, pipeline_configuration_file_p
     Logger.set_project_name(pipeline_configuration.pipeline_name)
     log.debug(f"Pipeline name is {pipeline_configuration.pipeline_name}")
 
-    if pipeline_configuration.phone_number_uuid_table is not None:
-        log.info("Downloading Firestore UUID Table credentials...")
-        firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
-            google_cloud_credentials_file_path,
-            pipeline_configuration.phone_number_uuid_table.firebase_credentials_file_url
-        ))
+    log.info("Downloading Firestore UUID Table credentials...")
+    firestore_uuid_table_credentials = json.loads(google_cloud_utils.download_blob_to_string(
+        google_cloud_credentials_file_path,
+        pipeline_configuration.uuid_table.firebase_credentials_file_url
+    ))
 
-        phone_number_uuid_table = FirestoreUuidTable(
-            pipeline_configuration.phone_number_uuid_table.table_name,
-            firestore_uuid_table_credentials,
-            "avf-phone-uuid-"
-        )
-        log.info("Initialised the Firestore UUID table")
+    uuid_table = FirestoreUuidTable(
+        pipeline_configuration.uuid_table.table_name,
+        firestore_uuid_table_credentials,
+        pipeline_configuration.uuid_table.uuid_prefix
+    )
+    log.info("Initialised the Firestore UUID table")
 
     log.info(f"Fetching data from {len(pipeline_configuration.raw_data_sources)} sources...")
     for i, raw_data_source in enumerate(pipeline_configuration.raw_data_sources):
         log.info(f"Fetching from source {i + 1}/{len(pipeline_configuration.raw_data_sources)}...")
         if isinstance(raw_data_source, RapidProSource):
-            fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table,
+            fetch_from_rapid_pro(user, google_cloud_credentials_file_path, raw_data_dir, uuid_table,
                                  raw_data_source)
         elif isinstance(raw_data_source, GCloudBucketSource):
             fetch_from_gcloud_bucket(google_cloud_credentials_file_path, raw_data_dir, raw_data_source)
         elif isinstance(raw_data_source, RecoveryCSVSource):
-            fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table,
+            fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_dir, uuid_table,
                                     raw_data_source)
         elif isinstance(raw_data_source, FacebookSource):
-            fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, raw_data_source)
+            fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, uuid_table,
+                                raw_data_source)
         else:
             assert False, f"Unknown raw_data_source type {type(raw_data_source)}"
 

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -212,7 +212,10 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
         for post_id in dataset.post_ids:
             comments_log_path = f"{raw_data_dir}/{post_id}_comments_log.jsonl"
             with open(comments_log_path, "a") as raw_comments_log_file:
-                post_comments = facebook.get_all_comments_on_post(post_id, raw_export_log_file=raw_comments_log_file)
+                post_comments = facebook.get_all_comments_on_post(
+                  post_id, raw_export_log_file=raw_comments_log_file,
+                  fields=["from{id}", "parent", "attachments", "created_time", "message"]
+                )
 
             # Download the post and add it as context to all the comments. Adding a reference to the post under
             # which a comment was made enables downstream features such as post-type labelling and comment context

--- a/fetch_raw_data.py
+++ b/fetch_raw_data.py
@@ -194,7 +194,7 @@ def fetch_from_recovery_csv(user, google_cloud_credentials_file_path, raw_data_d
         log.info(f"Exported TracedData")
 
 
-def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, phone_number_uuid_table, facebook_source):
+def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, facebook_uuid_table, facebook_source):
     log.info("Fetching data from Facebook...")
     log.info("Downloading Facebook access token...")
     facebook_token = google_cloud_utils.download_blob_to_string(
@@ -234,7 +234,7 @@ def fetch_from_facebook(user, google_cloud_credentials_file_path, raw_data_dir, 
 
         # Convert the comments to TracedData.
         traced_comments = facebook.convert_facebook_comments_to_traced_data(
-            user, dataset.name, raw_comments, phone_number_uuid_table)
+            user, dataset.name, raw_comments, facebook_uuid_table)
 
         # Export to disk.
         log.info(f"Saving {len(raw_comments)} raw comments to {raw_comments_output_path}...")

--- a/src/analysis_file.py
+++ b/src/analysis_file.py
@@ -13,9 +13,13 @@ from src.lib import PipelineConfiguration, ConsentUtils
 from src.lib.configuration_objects import CodingModes
 
 
+MESSAGES_FILE = "messages_file"
+INDIVIDUALS_FILE = "individuals_file"
+
+
 class AnalysisFile(object):
     @staticmethod
-    def export_to_csv(user, data, csv_path, export_keys, consent_withdrawn_key):
+    def export_to_csv(analysis_file_type, data, csv_path, export_keys, consent_withdrawn_key):
         with open(csv_path, "w") as f:
             writer = csv.DictWriter(f, fieldnames=export_keys, lineterminator="\n")
             writer.writeheader()
@@ -36,6 +40,9 @@ class AnalysisFile(object):
                 for plan in PipelineConfiguration.RQA_CODING_PLANS + PipelineConfiguration.SURVEY_CODING_PLANS:
                     for cc in plan.coding_configurations:
                         if cc.analysis_file_key is None:
+                            continue
+
+                        if analysis_file_type == INDIVIDUALS_FILE and not cc.include_in_individuals_file:
                             continue
 
                         if cc.coding_mode == CodingModes.SINGLE:
@@ -94,7 +101,8 @@ class AnalysisFile(object):
                     for code in cc.code_scheme.codes:
                         export_keys.append(f"{cc.analysis_file_key}_{code.string_value}")
 
-                fold_strategies[cc.coded_field] = cc.fold_strategy
+                if cc.include_in_individuals_file:
+                    fold_strategies[cc.coded_field] = cc.fold_strategy
 
             export_keys.append(plan.raw_field)
             fold_strategies[plan.raw_field] = plan.raw_field_fold_strategy
@@ -111,7 +119,7 @@ class AnalysisFile(object):
         ConsentUtils.set_stopped(user, data, consent_withdrawn_key)
         ConsentUtils.set_stopped(user, folded_data, consent_withdrawn_key)
 
-        cls.export_to_csv(user, data, csv_by_message_output_path, export_keys, consent_withdrawn_key)
-        cls.export_to_csv(user, folded_data, csv_by_individual_output_path, export_keys, consent_withdrawn_key)
+        cls.export_to_csv(MESSAGES_FILE, data, csv_by_message_output_path, export_keys, consent_withdrawn_key)
+        cls.export_to_csv(INDIVIDUALS_FILE, folded_data, csv_by_individual_output_path, export_keys, consent_withdrawn_key)
 
         return data, folded_data

--- a/src/analysis_utils.py
+++ b/src/analysis_utils.py
@@ -19,6 +19,9 @@ class AnalysisUtils(object):
         :return: All the codes for the labels in the TracedData specified by the coding configuration `cc`.
         :rtype: list of Code
         """
+        if cc.coded_field not in td:
+            return []
+
         if cc.coding_mode == CodingModes.SINGLE:
             labels = [td[cc.coded_field]]
         else:
@@ -116,6 +119,9 @@ class AnalysisUtils(object):
             return False
 
         for cc in coding_plan.coding_configurations:
+            if not cc.include_in_individuals_file:
+                continue
+
             codes = cls._get_td_codes_for_coding_configuration(td, cc)
             if len(codes) == 0:
                 return False
@@ -149,6 +155,9 @@ class AnalysisUtils(object):
             return False
         
         for cc in coding_plan.coding_configurations:
+            if not cc.include_in_individuals_file:
+                continue
+
             codes = cls._get_td_codes_for_coding_configuration(td, cc)
             for code in codes:
                 if code.code_type == CodeTypes.NORMAL:

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -132,22 +132,18 @@ class FacebookClient(object):
         traced_comments = []
         # Use a placeholder avf facebook id for now, to make the individuals file work until we know if we'll be able
         # to see Facebook user ids or not.
-        # TODO: If we get ids from FB, de-identify instead of incrementing this placeholder;
-        #       If we don't get ids from FB, re-configure the pipeline to make processing individuals optional
-        avf_facebook_id = 0
         for comment in raw_comments:
             comment["created_time"] = isoparse(comment["created_time"]).isoformat()
             validators.validate_utc_iso_string(comment["created_time"])
 
             comment_dict = {
-                "avf_facebook_id": f"{dataset_name}_{avf_facebook_id}",  # TODO: De-identify a user's FB id here if possible instead
+                "avf_facebook_id": comment["from"]["id"]
             }
             for k, v in comment.items():
                 comment_dict[f"{dataset_name}.{k}"] = v
 
             traced_comments.append(
                 TracedData(comment_dict, Metadata(user, Metadata.get_call_location(), TimeUtils.utc_now_as_iso_string())))
-            avf_facebook_id += 1
 
         log.info(f"Converted {len(traced_comments)} Facebook comments to TracedData")
 

--- a/src/facebook_client.py
+++ b/src/facebook_client.py
@@ -126,8 +126,11 @@ class FacebookClient(object):
         return comments
 
     @staticmethod
-    def convert_facebook_comments_to_traced_data(user, dataset_name, raw_comments):
+    def convert_facebook_comments_to_traced_data(user, dataset_name, raw_comments, facebook_uuid_table):
         log.info(f"Converting {len(raw_comments)} Facebook comments to TracedData...")
+
+        facebook_uuids = {comment["from"]["id"] for comment in raw_comments}
+        facebook_to_uuid_lut = facebook_uuid_table.data_to_uuid_batch(facebook_uuids)
 
         traced_comments = []
         # Use a placeholder avf facebook id for now, to make the individuals file work until we know if we'll be able
@@ -137,7 +140,7 @@ class FacebookClient(object):
             validators.validate_utc_iso_string(comment["created_time"])
 
             comment_dict = {
-                "avf_facebook_id": comment["from"]["id"]
+                "avf_facebook_id": facebook_to_uuid_lut[comment["from"]["id"]]
             }
             for k, v in comment.items():
                 comment_dict[f"{dataset_name}.{k}"] = v

--- a/src/lib/configuration_objects.py
+++ b/src/lib/configuration_objects.py
@@ -9,7 +9,7 @@ class CodingModes(object):
 class CodingConfiguration(object):
     def __init__(self, coding_mode, code_scheme, coded_field, fold_strategy, raw_field=None,
                  requires_manual_verification=True, analysis_file_key=None, cleaner=None,
-                 include_in_theme_distribution=True):
+                 include_in_theme_distribution=True, include_in_individuals_file=True):
         assert coding_mode in {CodingModes.SINGLE, CodingModes.MULTIPLE}
 
         self.coding_mode = coding_mode
@@ -21,6 +21,7 @@ class CodingConfiguration(object):
         self.fold_strategy = fold_strategy
         self.cleaner = cleaner
         self.include_in_theme_distribution = include_in_theme_distribution
+        self.include_in_individuals_file = include_in_individuals_file
 
 
 class CodingPlan(object):

--- a/src/lib/pipeline_configuration.py
+++ b/src/lib/pipeline_configuration.py
@@ -17,7 +17,7 @@ class PipelineConfiguration(object):
     SURVEY_CODING_PLANS = []
     WS_CORRECT_DATASET_SCHEME = None
 
-    def __init__(self, pipeline_name, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+    def __init__(self, pipeline_name, raw_data_sources, uuid_table, timestamp_remappings,
                  source_key_remappings, project_start_date, project_end_date, filter_test_messages, move_ws_messages,
                  memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
                  automated_analysis, drive_upload=None):
@@ -26,8 +26,8 @@ class PipelineConfiguration(object):
         :type pipeline_name: str
         :param raw_data_sources: List of sources to pull the various raw run files from.
         :type raw_data_sources: list of RawDataSource
-        :param phone_number_uuid_table: Configuration for the Firestore phone number <-> uuid table.
-        :type phone_number_uuid_table: PhoneNumberUuidTable
+        :param uuid_table: Configuration for the Firestore source id <-> avf uuid table.
+        :type uuid_table: UuidTable
         :param source_key_remappings: List of source_key -> pipeline_key remappings.
         :type source_key_remappings: list of SourceKeyRemapping
         :param project_start_date: When data collection started - all activation messages received before this date
@@ -57,7 +57,7 @@ class PipelineConfiguration(object):
         """
         self.pipeline_name = pipeline_name
         self.raw_data_sources = raw_data_sources
-        self.phone_number_uuid_table = phone_number_uuid_table
+        self.uuid_table = uuid_table
         self.timestamp_remappings = timestamp_remappings
         self.source_key_remappings = source_key_remappings
         self.project_start_date = project_start_date
@@ -97,10 +97,8 @@ class PipelineConfiguration(object):
                 assert False, f"Unknown SourceType '{raw_data_source['SourceType']}'. " \
                               f"Must be 'RapidPro', 'GCloudBucket', 'RecoveryCSV', or 'Facebook'."
 
-        phone_number_uuid_table = None
-        if "PhoneNumberUuidTable" in configuration_dict:
-            phone_number_uuid_table = PhoneNumberUuidTable.from_configuration_dict(
-                configuration_dict["PhoneNumberUuidTable"])
+        uuid_table = UuidTable.from_configuration_dict(
+            configuration_dict["UuidTable"])
 
         timestamp_remappings = []
         for remapping_dict in configuration_dict.get("TimestampRemappings", []):
@@ -126,7 +124,7 @@ class PipelineConfiguration(object):
         data_archive_upload_bucket = configuration_dict["DataArchiveUploadBucket"]
         bucket_dir_path = configuration_dict["BucketDirPath"]
 
-        return cls(pipeline_name, raw_data_sources, phone_number_uuid_table, timestamp_remappings,
+        return cls(pipeline_name, raw_data_sources, uuid_table, timestamp_remappings,
                    source_key_remappings, project_start_date, project_end_date, filter_test_messages,
                    move_ws_messages, memory_profile_upload_bucket, data_archive_upload_bucket, bucket_dir_path,
                    automated_analysis, drive_upload_paths)
@@ -143,13 +141,8 @@ class PipelineConfiguration(object):
             assert isinstance(raw_data_source, RawDataSource), f"raw_data_sources[{i}] is not of type RawDataSource"
             raw_data_source.validate()
 
-        if self.phone_number_uuid_table is None:
-            for i, raw_data_source in enumerate(self.raw_data_sources):
-                assert isinstance(raw_data_source, FacebookSource), \
-                    f"phone_number_uuid_table is None, but raw_data_source[{i}] requires a uuid table"
-        else:
-            assert isinstance(self.phone_number_uuid_table, PhoneNumberUuidTable)
-            self.phone_number_uuid_table.validate()
+        assert isinstance(self.uuid_table, UuidTable)
+        self.uuid_table.validate()
 
         validators.validate_list(self.source_key_remappings, "source_key_remappings")
         for i, remapping in enumerate(self.source_key_remappings):
@@ -343,17 +336,18 @@ class FacebookDataset(object):
             validators.validate_string(post_id, f"post_ids[{i}]")
 
 
-class PhoneNumberUuidTable(object):
-    def __init__(self, firebase_credentials_file_url, table_name):
+class UuidTable(object):
+    def __init__(self, firebase_credentials_file_url, table_name, uuid_prefix):
         """
         :param firebase_credentials_file_url: GS URL to the private credentials file for the Firebase account where
-                                                 the phone number <-> uuid table is stored.
+                                              the source id <-> avf uuid table is stored.
         :type firebase_credentials_file_url: str
         :param table_name: Name of the data <-> uuid table in Firebase to use.
         :type table_name: str
         """
         self.firebase_credentials_file_url = firebase_credentials_file_url
         self.table_name = table_name
+        self.uuid_prefix = uuid_prefix
 
         self.validate()
 
@@ -361,12 +355,14 @@ class PhoneNumberUuidTable(object):
     def from_configuration_dict(cls, configuration_dict):
         firebase_credentials_file_url = configuration_dict["FirebaseCredentialsFileURL"]
         table_name = configuration_dict["TableName"]
+        uuid_prefix = configuration_dict["UuidPrefix"]
 
-        return cls(firebase_credentials_file_url, table_name)
+        return cls(firebase_credentials_file_url, table_name, uuid_prefix)
 
     def validate(self):
         validators.validate_url(self.firebase_credentials_file_url, "firebase_credentials_file_url", scheme="gs")
         validators.validate_string(self.table_name, "table_name")
+        validators.validate_string(self.uuid_prefix, "uuid_prefix")
 
 
 class TimestampRemapping(object):
@@ -511,6 +507,7 @@ class DriveUpload(object):
         validators.validate_string(self.messages_upload_path, "messages_upload_path")
         validators.validate_string(self.individuals_upload_path, "individuals_upload_path")
         validators.validate_string(self.automated_analysis_dir, "automated_analysis_dir")
+
 
 class AutomatedAnalysis(object):
     def __init__(self, generate_region_theme_distribution_maps, generate_district_theme_distribution_maps,

--- a/upload_analysis_files.py
+++ b/upload_analysis_files.py
@@ -78,15 +78,12 @@ if __name__ == "__main__":
                                                   target_folder_is_shared_with_me=True, recursive=True,
                                                   fix_duplicates=True)
 
-            if pipeline_configuration.pipeline_name != "TIS-Plus-Facebook":
-                # Don't upload the individuals file until we have access to user ids from Facebook, so as not to
-                # confuse the RAs
-                individuals_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.individuals_upload_path)
-                individuals_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.individuals_upload_path)
-                drive_client_wrapper.update_or_create(individuals_csv_input_path, individuals_csv_drive_dir,
-                                                      target_file_name=individuals_csv_drive_file_name,
-                                                      target_folder_is_shared_with_me=True, recursive=True,
-                                                      fix_duplicates=True)
+            individuals_csv_drive_dir = os.path.dirname(pipeline_configuration.drive_upload.individuals_upload_path)
+            individuals_csv_drive_file_name = os.path.basename(pipeline_configuration.drive_upload.individuals_upload_path)
+            drive_client_wrapper.update_or_create(individuals_csv_input_path, individuals_csv_drive_dir,
+                                                  target_file_name=individuals_csv_drive_file_name,
+                                                  target_folder_is_shared_with_me=True, recursive=True,
+                                                  fix_duplicates=True)
 
             paths_to_upload = glob(f"{automated_analysis_input_dir}/*.csv")
             log.info(f"Uploading {len(paths_to_upload)} CSVs to Drive...")


### PR DESCRIPTION
This PR incorporates all the changes needed to use Facebook user ids and do a minimal analysis of the data. 

Mostly, this should be straightforward to read. The main changes are:
 - Requesting user{id}s from Facebook's API
 - De-identifying these ids as we would phone numbers. This de-identification is less important for the Facebook ids than phone numbers because the ids are scoped to our app - so if they leak they're useless without access to our service account. However, to make this extra tight and so we don't need to audit a new method of de-identification, and for consistency in uid formatting, I think we should de-identify these ids just as we would for phone numbers. The main consequence of this is the need to generalise the PhoneNumberUuidTable configuration to a more general UuidTable. 

The main interesting change is the introduction of another parameter in the coding configurations, `include_in_individuals_file`. This is necessary so we can exclude the "context" fields which made sense in the messages file but don't make sense for the individuals data (where the "context" fields are post type and comment reply to).